### PR TITLE
Remove minSdkVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ To see a list of other available PhoneGap templates:
 
 ## [config.xml][config-xml]
 
-#### android-minSdkVersion (Android only)
-
-Minimum SDK version supported on the target device. Maximum version is blank by default.
-
-This template sets the minimum to `14`.
-
-    <preference name="android-minSdkVersion" value="14" />
-
 #### &lt;access ...&gt; (All)
 
 This template defaults to wide open access.

--- a/www/config.xml
+++ b/www/config.xml
@@ -21,8 +21,6 @@
 
     <!-- Customize your app and platform with the preference element. -->
     <preference name="DisallowOverscroll"         value="true" />
-    <!-- android: MIN SDK version supported on the target device. MAX version is blank by default. -->
-    <preference name="android-minSdkVersion"      value="14" />
 
     <!-- Define a specific version of PhoneGap to build into your app. -->
     <!-- <preference name="phonegap-version"       value="cli-6.0.0" /> -->


### PR DESCRIPTION
Remove minSdkVersion as CordovaLib requires a greater one and it will require a bigger one in the future, so better just remove it as it adds no value to the template

@stevengill @macdonst @devgeeks 